### PR TITLE
Correccion en la ruta principal

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -8,7 +8,7 @@ import {LoginComponent} from "./login/login.component";
 
 
 const routes: Routes = [
-  {path: '', redirectTo: '/listaModulos', pathMatch : 'full'},
+  {path: '', redirectTo: 'listaModulos', pathMatch : 'full'},
   {path: 'listaModulos', component: IcfesModulesListComponent},
   {path: 'listaTests/:moduleId', component: TestListComponent},
   {path: 'test/:testId/:moduleId', component: IcfesTestComponent,


### PR DESCRIPTION
el redireccionamiento estaba llevando a la ruta "/listaModulos" lo cual funcionaba, pero cuando se recargaba la pagina, aparecia error 404 solamente fue quitar el / para mantener todas las rutas iguales, ya con eso se arreglo